### PR TITLE
Viridianforge/protobuf version updates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,8 @@ jobs:
           pip install -r requirements-lint.txt
       - name: Lint and check formatting with ruff
         run: |
-          ruff check src/grpc_requests/*.py src/tests/*.py --statistics --config ruff.toml
-          ruff format src/grpc_requests/*.py src/tests/*.py --check --config ruff.toml
+          ruff check src/ --statistics --config ruff.toml
+          ruff format src/ --check --config ruff.toml
       - name: Typecheck with mypy
         run: |
           mypy src/grpc_requests/*.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,30 @@ on:
       - master
 
 jobs:
+  run_checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-lint.txt
+      - name: Lint and check formatting with ruff
+        run: |
+          ruff check src/grpc_requests/*.py src/tests/*.py --statistics --config ruff.toml
+          ruff format src/grpc_requests/*.py src/tests/*.py --check --config ruff.toml
+      - name: Typecheck with mypy
+        run: |
+          mypy src/grpc_requests/*.py
   run_tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        protobuf-version: ["4.25.4", "5.27.3"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -21,15 +40,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
           pip install -e .
-      - name: Lint and check formatting with ruff
-        run: |
-          ruff check src/grpc_requests/*.py src/tests/*.py --statistics --config ruff.toml
-          ruff format src/grpc_requests/*.py src/tests/*.py --check --config ruff.toml
-      - name: Typecheck with mypy
-        run: |
-          mypy src/grpc_requests/*.py
+          pip install -r requirements-test.txt
+          pip install protobuf==${{ matrix.protobuf-version }}
       - name: Test with pytest
         run: |
           pytest --cov-report=xml --cov=src/grpc_requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,48 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.19](https://github.com/grpc-requests/grpc_requests/releases/tag/v0.1.19) - 2024-07-xx
+
+### Added
+
+- Tools for developers to measure complexity of the code base
+- Integrations with mypy
+
+### Removed
+
+Support for Python 3.7
+
 ## [0.1.18](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.18) - 2024-05-18
 
-## Added
+### Added
 
 - Support for lazy loading of services in async clients
 
 ## [0.1.17](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.17) - 2024-04-22
 
-## Added
+### Added
 
 - Support for custom message parsing in both async and sync clients
 
-## Removed
+### Removed
 
 - Removed singular FileDescriptor getter methods and Method specific field descriptor
   methods as laid out previously.
 
 ## [0.1.16](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.16) - 2024-03-03
 
-## Added
+### Added
 
 - Additional usage examples
 
-## Fixed
+### Fixed
 
 - Put deprecation warnings in the correct place for old get_descriptor methods, so they do not warn at all times.
 
 ## [0.1.15](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.15) - 2024-02-17
 
-## Added
+### Added
 
 - Add methods to return FileDescriptors and their transistive dependencies as requested by either a name or symbol
 - Add option to skip automatic checking of method availability
 
-## Deprecated
+### Deprecated
 
 - Due to the possibility of transient dependencies being missed, or other name or symbol collisions, methods to access singular FileDescriptors are deprecated and will be removed in version 0.1.17
 - The method to retrieve fields of a method's descriptor input type alone will be removed in version 0.1.17
 
 ## [0.1.14](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.14) - 2024-01-06
 
-## Added
+### Added
 
 - MethodMetaData accessible to clients
 - MethodDescriptors accessible via MethodMetaData
@@ -55,49 +66,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.13](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.13) - 2023-12-03
 
-## Added
+### Added
 
 - Added channel interceptors for standard and async clients
 
-## Fixed
+### Fixed
 
 - Refactored how methods and services are added to description pool to better avoid cases where FileDescriptors may be added twice.
 
 ## [0.1.12](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.12) - 2023-11-26
 
-## Added
+### Added
 
 - Method to print out a generic descriptor added to utils collection
 - Helper methods to print out a method's request and responses in a human readable format
 
-## Changed
+### Changed
 
 - Documentation revamped
 - Version checks to avoid using deprecated methods added to async client
 
-## Fixed
+### Fixed
 
 - Include `requirements.txt` in build manifest
 
-## Deprecated
+### Deprecated
 
 - Method to retrieve fields for the descriptor of a method's input type.
-
-## Added
 
 ## [0.1.11](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.11) - 2023-10-05
 
-## Added
+### Added
 
 - Method to retrieve fields for the descriptor of a method's input type.
 
-## Changes
+### Changes
 
 - Updates to minimum versons of requirements to address vulnerabilities
 
 ## [0.1.10](https://github.com/wesky93/grpc_requests/releases/tag/v0.1.10) - 2023-03-07
 
-## Fixed
+### Fixed
 
 - Corrected pin of `protobuf` version in `requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ from grpc_requests import Client
 client = Client.get_by_endpoint("localhost:50051")
 assert client.service_names == ["helloworld.Greeter"]
 
-request_data = {"name": "sinsky"} 
+request_data = {"name": "sinsky"}
 say_hello_response = client.request("helloworld.Greeter", "SayHello", request_data)
 assert say_hello_response ==  {"message":"Hello sinsky!"}
 ```
@@ -60,14 +60,27 @@ usage scenarioes, and the [unit tests](./src/tests/) are also a useful reference
 
 Contributions from the community are welcomed and greatly appreciated.
 
-Before opening a PR, [tests.sh](./tests.sh) can be used to ensure the contribution passes
-linting and unit test checks. You can also run [complexity.sh](./complexity.sh) to use
+Before opening a PR, running `python -m nox` can be used to ensure the contribution passes
+linting and unit test checks for all supported versions of Python and protobuf.
+You can also run [complexity.sh](./complexity.sh) to use
 [radon](https://pypi.org/project/radon/) to look at the cyclomatic complexity,
 maintainability index, and Halstead effort and difficulty of files.
 
 PRs should be targeted to merge with the `develop` branch. When opening a PR,
 please assign it to a maintainer for review. The maintainers will take it from
 there.
+
+## Compatibility
+
+`grpc_requests` currently does its best to support versions of Python and
+protobuf that are within their support lifetimes. You may find that other versions
+of dependencies work with the library, but this should be treated as a happy accident.
+
+For Python, we target versions that are in the security and bugfix phases.
+For protobuf, we target versions that in their public support phase.
+
+[Python's support matrix](https://devguide.python.org/versions/)
+[Protobuf's support matrix](https://protobuf.dev/support/version-support/#python)
 
 ## Questions, Comments, Issues?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # grpc_requests
 
+[![Nox](https://img.shields.io/badge/%F0%9F%A6%8A-Nox-D85E00.svg)](https://github.com/wntrblm/nox)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![PyPI](https://img.shields.io/pypi/v/grpc-requests?style=flat-square)](https://pypi.org/project/grpc-requests)

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,3 +15,10 @@ def tests(session, protobuf):
     session.install(f"protobuf=={protobuf}")
     session.run("pip", "list")
     session.run("pytest")
+
+@nox.session
+def lint(session):
+    session.install("-r", "requirements-lint.txt")
+    session.run("ruff", "check", "src/grpc_requests/", "--statistics", "--config", "ruff.toml")
+    session.run("ruff", "format", "src/grpc_requests/", "--check", "--config", "ruff.toml")
+    session.run("mypy", "src/grpc_requests/")

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,16 +9,15 @@ import nox
         for protobuf in ["4.25.4","5.27.3"]
     ]
 )
-def tests(session, protobuf):
+def test(session, protobuf):
     session.install("-e",".")
     session.install("-r", "requirements-test.txt")
     session.install(f"protobuf=={protobuf}")
-    session.run("pip", "list")
     session.run("pytest")
 
 @nox.session
 def lint(session):
     session.install("-r", "requirements-lint.txt")
-    session.run("ruff", "check", "src/grpc_requests/", "--statistics", "--config", "ruff.toml")
-    session.run("ruff", "format", "src/grpc_requests/", "--check", "--config", "ruff.toml")
+    session.run("ruff", "check", "src/", "--statistics", "--config", "ruff.toml")
+    session.run("ruff", "format", "src/", "--config", "ruff.toml")
     session.run("mypy", "src/grpc_requests/")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,17 @@
+import nox
+
+@nox.session
+@nox.parametrize(
+    "python,protobuf",
+    [
+        (python, protobuf)
+        for python in ["3.8","3.9","3.10","3.11","3.12"]
+        for protobuf in ["4.25.4","5.27.3"]
+    ]
+)
+def tests(session, protobuf):
+    session.install("-e",".")
+    session.install("-r", "requirements-test.txt")
+    session.install(f"protobuf=={protobuf}")
+    session.run("pip", "list")
+    session.run("pytest")

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,4 @@
+grpc-stubs >= 1.53.0
+mypy>=1.10.0
+ruff>=0.1.7
+types-protobuf>=5.26.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,16 +1,11 @@
--r requirements.txt
-setuptools>=59.7.0
-wheel>=0.38.4
-twine>=4.0.2
-flake8>=5.0.4
+grpcio >= 1.60.1
+grpcio-reflection >= 1.60.1
+google-api-core>=2.11.1
+cryptography>=41.0.7
 pytest-cov>=4.0.0
 pytest-asyncio>=0.15.1
 aiounittest>=1.4.2
 grpc-interceptor>=0.15.4
-ruff>=0.1.7
-grpcio-tools>=1.60.1
 grpc-stubs >= 1.53.0
 types-protobuf>=5.26.0
-radon>=6.0.1
 mypy>=1.10.0
-nox>=2024.4.15

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,3 @@ pytest-cov>=4.0.0
 pytest-asyncio>=0.15.1
 aiounittest>=1.4.2
 grpc-interceptor>=0.15.4
-grpc-stubs >= 1.53.0
-types-protobuf>=5.26.0
-mypy>=1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 grpcio >= 1.60.1
 grpcio-reflection >= 1.60.1
-protobuf>=3.20.3,<5.0.0dev
+protobuf>=3.20.3
 google-api-core>=2.11.1
 cryptography>=41.0.7

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,9 @@
 target-version = "py38"
 
+# Exclude compiled Protobuf files
+exclude = ["**/*_pb2.py", "**/*_pb2_grpc.py", "**/*_pb2.pyi", "**/*_pb2_grpc.pyi"]
+
+
 [lint]
 # Bugbear Rules
 select = ["E4", "E7", "E9", "C4", "C90", "F", "B", "SIM", "PERF"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,4 @@
-# Continue supporting python 3.7
-target-version = "py37"
+target-version = "py38"
 
 [lint]
 # Bugbear Rules
@@ -14,6 +13,3 @@ unfixable = ["B"]
 [lint.per-file-ignores]
 "__init__.py" = ["E402"]
 "**/{tests,docs,tools}/*" = ["E402"]
-
-
-

--- a/src/examples/client_tester_client.py
+++ b/src/examples/client_tester_client.py
@@ -9,17 +9,17 @@ In order for this example to work, the example helloworld server must be
 running.
 """
 
-host = 'localhost'
-port = '50051'
+host = "localhost"
+port = "50051"
 endpoint = f"{host}:{port}"
 
 client = Client.get_by_endpoint(endpoint)
 
-service = 'client_tester.ClientTester'
+service = "client_tester.ClientTester"
 
 # Unary-Unary Example
 
-unary_unary_method = 'TestUnaryUnary'
+unary_unary_method = "TestUnaryUnary"
 unary_unary_request = {}
 
 response = client.unary_unary(service, unary_unary_method, unary_unary_request)
@@ -27,7 +27,7 @@ print(response)
 
 # Unary-Stream Example
 
-unary_stream_method = 'TestUnaryStream'
+unary_stream_method = "TestUnaryStream"
 unary_stream_request = {}
 
 responses = client.unary_stream(service, unary_stream_method, unary_stream_request)
@@ -35,7 +35,7 @@ print(responses)
 
 # Stream-Unary Example
 
-stream_unary_method = 'TestStreamUnary'
+stream_unary_method = "TestStreamUnary"
 stream_unary_request = [{}, {}, {}]
 
 response = client.stream_unary(service, stream_unary_method, stream_unary_request)
@@ -43,7 +43,7 @@ print(response)
 
 # Stream-Stream Example
 
-stream_stream_method = 'TestStreamStream'
+stream_stream_method = "TestStreamStream"
 stream_stream_request = [{}, {}, {}]
 
 responses = client.stream_stream(service, stream_stream_method, stream_stream_request)

--- a/src/examples/helloworld_reflection.py
+++ b/src/examples/helloworld_reflection.py
@@ -9,19 +9,19 @@ In order for this example to work, the example helloworld server must be
 running.
 """
 
-host = 'localhost'
-port = '50051'
+host = "localhost"
+port = "50051"
 endpoint = f"{host}:{port}"
 
 client = Client.get_by_endpoint(endpoint)
 
-service = 'helloworld.Greeter'
+service = "helloworld.Greeter"
 name_list = ["sinsky", "viridianforge", "jack", "harry"]
 name_string = " ".join(name_list)
 
 # Unary-Unary Example
 
-unary_unary_method = 'SayHello'
+unary_unary_method = "SayHello"
 unary_unary_request = {"name": "sinsky"}
 
 response = client.unary_unary(service, unary_unary_method, unary_unary_request)
@@ -30,7 +30,7 @@ assert response == {"message": "Hello, sinsky!"}
 
 # Unary-Stream Example
 
-unary_stream_method = 'SayHelloGroup'
+unary_stream_method = "SayHelloGroup"
 unary_stream_request = {"name": "".join(name_list)}
 
 responses = client.unary_stream(service, unary_stream_method, unary_stream_request)
@@ -40,16 +40,16 @@ for response, name in zip(responses, name_list):
 
 # Stream-Unary Example
 
-stream_unary_method = 'HelloEveryone'
+stream_unary_method = "HelloEveryone"
 stream_unary_request = [{"name": name} for name in name_list]
 
 response = client.stream_unary(service, stream_unary_method, stream_unary_request)
 assert isinstance(response, dict)
-assert response == {'message': f"Hello, {name_string}!"}
+assert response == {"message": f"Hello, {name_string}!"}
 
 # Stream-Stream Example
 
-stream_stream_method = 'SayHelloOneByOne'
+stream_stream_method = "SayHelloOneByOne"
 stream_stream_request = [{"name": name} for name in name_list]
 
 responses = client.stream_stream(service, stream_stream_method, stream_stream_request)

--- a/src/examples/helloworld_server.py
+++ b/src/examples/helloworld_server.py
@@ -14,22 +14,23 @@ formatter = logging.Formatter()
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s : %(levelname)s : %(name)s : %(message)s',
-    handlers=[stdout_handler]
+    format="%(asctime)s : %(levelname)s : %(name)s : %(message)s",
+    handlers=[stdout_handler],
 )
 
 logger = logging.getLogger(__name__)
 
 
 class Greeter(helloworld_proto.helloworld_pb2_grpc.GreeterServicer):
-
     def SayHello(self, request, context):
         """
         Unary-Unary
         Sends a HelloReply based on a HelloRequest.
         """
         logger.info(f"SayHello received request: {request}.")
-        return helloworld_proto.helloworld_pb2.HelloReply(message=f"Hello, {request.name}!")
+        return helloworld_proto.helloworld_pb2.HelloReply(
+            message=f"Hello, {request.name}!"
+        )
 
     def SayHelloGroup(self, request, context):
         """
@@ -54,7 +55,9 @@ class Greeter(helloworld_proto.helloworld_pb2_grpc.GreeterServicer):
             names.append(request.name)
             logger.info(names)
         names_string = " ".join(names)
-        return helloworld_proto.helloworld_pb2.HelloReply(message=f"Hello, {names_string}!")
+        return helloworld_proto.helloworld_pb2.HelloReply(
+            message=f"Hello, {names_string}!"
+        )
 
     def SayHelloOneByOne(self, request_iterator, context):
         """
@@ -63,25 +66,31 @@ class Greeter(helloworld_proto.helloworld_pb2_grpc.GreeterServicer):
         """
         logger.info("SayHelloOneByOne received request.")
         for request in request_iterator:
-            yield helloworld_proto.helloworld_pb2.HelloReply(message=f"Hello {request.name}")
+            yield helloworld_proto.helloworld_pb2.HelloReply(
+                message=f"Hello {request.name}"
+            )
 
 
 def serve():
     logger.info("Configuring Helloworld Server...")
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    helloworld_proto.helloworld_pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
+    helloworld_proto.helloworld_pb2_grpc.add_GreeterServicer_to_server(
+        Greeter(), server
+    )
     SERVICE_NAMES = (
-        helloworld_proto.helloworld_pb2.DESCRIPTOR.services_by_name['Greeter'].full_name,
+        helloworld_proto.helloworld_pb2.DESCRIPTOR.services_by_name[
+            "Greeter"
+        ].full_name,
         reflection.SERVICE_NAME,
     )
     reflection.enable_server_reflection(SERVICE_NAMES, server)
     logger.info("Reflection Enabled for Helloworld Server")
-    server.add_insecure_port('[::]:50051')
+    server.add_insecure_port("[::]:50051")
     server.start()
     logger.info("Helloworld Server running on port 50051")
     server.wait_for_termination()
     logger.info("Helloworld Server shutting down.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     serve()

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -35,6 +35,7 @@ def get_metadata(package_name: str):
 
 # Import GetMessageClass if protobuf version supports it
 protobuf_version = get_metadata("protobuf").split(".")
+print(protobuf_version)
 get_message_class_supported = (
     int(protobuf_version[0]) >= 4 and int(protobuf_version[1]) >= 22
 )

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -33,9 +33,7 @@ def get_metadata(package_name: str):
     return importlib.metadata.version(package_name)
 
 
-# Import GetMessageClass if protobuf version supports it
 protobuf_version = get_metadata("protobuf").split(".")
-print(protobuf_version)
 get_message_class_supported = (
     int(protobuf_version[0]) >= 4 and int(protobuf_version[1]) >= 22
 )

--- a/src/tests/async_reflection_client_test.py
+++ b/src/tests/async_reflection_client_test.py
@@ -24,6 +24,7 @@ Test cases for async reflection based client
 logger = logging.getLogger("name")
 reflection_service_name = "grpc.reflection.v1alpha.ServerReflection"
 
+
 def use_always_print():
     protobuf_version = importlib.metadata.version("protobuf").split(".")
     return protobuf_version[0] >= "5" and protobuf_version[1] >= "0"
@@ -295,7 +296,7 @@ async def test_stream_unary_defaults():
         [{"name": name} for name in name_list]
     )
     assert isinstance(response, dict)
-    assert response == {}
+    assert response == {"message": "Hello, sinsky viridianforge jack harry!"}
 
 
 @pytest.mark.asyncio
@@ -319,7 +320,7 @@ async def test_stream_unary_empty():
         [{"name": name} for name in name_list]
     )
     assert isinstance(response, dict)
-    assert response == {"message": ""}
+    assert response == {"message": "Hello, sinsky viridianforge jack harry!"}
 
 
 @pytest.mark.asyncio

--- a/src/tests/async_reflection_client_test.py
+++ b/src/tests/async_reflection_client_test.py
@@ -1,4 +1,5 @@
 import logging
+import importlib.metadata
 
 import grpc.aio
 import pytest
@@ -22,6 +23,10 @@ Test cases for async reflection based client
 
 logger = logging.getLogger("name")
 reflection_service_name = "grpc.reflection.v1alpha.ServerReflection"
+
+def use_always_print():
+    protobuf_version = importlib.metadata.version("protobuf").split(".")
+    return protobuf_version[0] >= "5" and protobuf_version[1] >= "0"
 
 
 @pytest.mark.asyncio
@@ -259,13 +264,16 @@ async def test_register_file_descriptors_incomplete_dependencies():
 
 @pytest.mark.asyncio
 async def test_unary_unary_defaults():
+    default_fields_method = "including_default_value_fields"
+    if use_always_print():
+        default_fields_method = "always_print_fields_with_no_presence"
     client = AsyncClient(
         "localhost:50054",
         descriptor_pool=descriptor_pool.DescriptorPool(),
         message_parsers=CustomArgumentParsers(
             message_to_dict_kwargs={
                 "preserving_proto_field_name": True,
-                "including_default_value_fields": True,
+                default_fields_method: True,
             }
         ),
     )
@@ -292,13 +300,16 @@ async def test_stream_unary_defaults():
 
 @pytest.mark.asyncio
 async def test_stream_unary_empty():
+    default_fields_method = "including_default_value_fields"
+    if use_always_print():
+        default_fields_method = "always_print_fields_with_no_presence"
     client = AsyncClient(
         "localhost:50054",
         descriptor_pool=descriptor_pool.DescriptorPool(),
         message_parsers=CustomArgumentParsers(
             message_to_dict_kwargs={
                 "preserving_proto_field_name": True,
-                "including_default_value_fields": True,
+                default_fields_method: True,
             }
         ),
     )
@@ -313,13 +324,16 @@ async def test_stream_unary_empty():
 
 @pytest.mark.asyncio
 async def test_stream_stream_empty():
+    default_fields_method = "including_default_value_fields"
+    if use_always_print():
+        default_fields_method = "always_print_fields_with_no_presence"
     client = AsyncClient(
         "localhost:50054",
         descriptor_pool=descriptor_pool.DescriptorPool(),
         message_parsers=CustomArgumentParsers(
             message_to_dict_kwargs={
                 "preserving_proto_field_name": True,
-                "including_default_value_fields": True,
+                default_fields_method: True,
             }
         ),
     )

--- a/src/tests/reflection_client_test.py
+++ b/src/tests/reflection_client_test.py
@@ -20,6 +20,7 @@ Test cases for reflection based client
 
 logger = logging.getLogger("name")
 
+
 def use_always_print():
     protobuf_version = importlib.metadata.version("protobuf").split(".")
     return protobuf_version[0] >= "5" and protobuf_version[1] >= "0"
@@ -339,7 +340,7 @@ def test_unary_stream_empty_custom(helloworld_empty_reflection_client_custom_par
     )
     assert all(isinstance(response, dict) for response in responses)
     for response, _ in zip(responses, name_list):
-        assert response == {"message": ""}
+        assert response == {"message": "Hello, sinsky viridianforge jack harry!"}
 
 
 def test_stream_unary_empty_default(helloworld_empty_reflection_client):
@@ -348,7 +349,7 @@ def test_stream_unary_empty_default(helloworld_empty_reflection_client):
         "helloworld.Greeter", "HelloEveryone", [{"name": name} for name in name_list]
     )
     assert isinstance(response, dict)
-    assert response == {}
+    assert response == {"message": "Hello, sinsky viridianforge jack harry!"}
 
 
 def test_stream_unary_empty_custom(helloworld_empty_reflection_client_custom_parsers):
@@ -357,7 +358,7 @@ def test_stream_unary_empty_custom(helloworld_empty_reflection_client_custom_par
         "helloworld.Greeter", "HelloEveryone", [{"name": name} for name in name_list]
     )
     assert isinstance(response, dict)
-    assert response == {"message": ""}
+    assert response == {"message": "Hello, sinsky viridianforge jack harry!"}
 
 
 def test_stream_stream_empty_default(helloworld_empty_reflection_client):

--- a/src/tests/reflection_client_test.py
+++ b/src/tests/reflection_client_test.py
@@ -2,6 +2,7 @@ import logging
 
 import grpc
 import pytest
+import importlib.metadata
 from google.protobuf import descriptor_pb2, descriptor_pool
 from google.protobuf.descriptor import MethodDescriptor
 from google.protobuf.json_format import ParseError
@@ -18,6 +19,10 @@ Test cases for reflection based client
 """
 
 logger = logging.getLogger("name")
+
+def use_always_print():
+    protobuf_version = importlib.metadata.version("protobuf").split(".")
+    return protobuf_version[0] >= "5" and protobuf_version[1] >= "0"
 
 
 @pytest.fixture(scope="module")
@@ -60,6 +65,9 @@ def helloworld_empty_reflection_client():
 
 @pytest.fixture(scope="module")
 def helloworld_empty_reflection_client_custom_parsers():
+    default_fields_method = "including_default_value_fields"
+    if use_always_print():
+        default_fields_method = "always_print_fields_with_no_presence"
     try:
         # Don't use get_by_endpoint here so we don't cache parsers
         client = Client(
@@ -67,7 +75,7 @@ def helloworld_empty_reflection_client_custom_parsers():
             message_parsers=CustomArgumentParsers(
                 message_to_dict_kwargs={
                     "preserving_proto_field_name": True,
-                    "including_default_value_fields": True,
+                    default_fields_method: True,
                 }
             ),
         )

--- a/src/tests/test_servers/client_tester/client_tester_server.py
+++ b/src/tests/test_servers/client_tester/client_tester_server.py
@@ -3,47 +3,49 @@ from grpc_reflection.v1alpha import reflection
 
 import grpc
 import logging
-from .client_tester_pb2_grpc import ClientTesterServicer, add_ClientTesterServicer_to_server
+from .client_tester_pb2_grpc import (
+    ClientTesterServicer,
+    add_ClientTesterServicer_to_server,
+)
 from .client_tester_pb2 import TestResponse, DESCRIPTOR
 
-class ClientTester(ClientTesterServicer):
 
+class ClientTester(ClientTesterServicer):
     def TestUnaryUnary(self, request, context):
         return TestResponse(average=0.0, feedback="Acceptable")
 
     def TestUnaryStream(self, request, context):
-        for reading in request.readings:
+        for _ in request.readings:
             yield TestResponse(average=0.0, feedback="Acceptable")
 
     def TestStreamUnary(self, request_iterator, context):
-        for request in request_iterator:
+        for _ in request_iterator:
             pass
         return TestResponse(average=0.0, feedback="Acceptable")
 
     def TestStreamStream(self, request_iterator, context):
         for request in request_iterator:
-            for reading in request.readings:
+            for _ in request.readings:
                 yield TestResponse(average=0.0, feedback="Acceptable")
 
 
-class ClientTesterServer():
-
+class ClientTesterServer:
     server = None
 
     def __init__(self, port: str):
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
         add_ClientTesterServicer_to_server(ClientTester(), self.server)
         SERVICE_NAMES = (
-            DESCRIPTOR.services_by_name['ClientTester'].full_name,
+            DESCRIPTOR.services_by_name["ClientTester"].full_name,
             reflection.SERVICE_NAME,
         )
         reflection.enable_server_reflection(SERVICE_NAMES, self.server)
-        self.server.add_insecure_port(f'[::]:{port}')
+        self.server.add_insecure_port(f"[::]:{port}")
 
     def serve(self):
-        logging.debug('Server starting...')
+        logging.debug("Server starting...")
         self.server.start()
-        logging.debug('Server running...')
+        logging.debug("Server running...")
         self.server.wait_for_termination()
 
     def shutdown(self):

--- a/src/tests/test_servers/dependencies/dependencies_server.py
+++ b/src/tests/test_servers/dependencies/dependencies_server.py
@@ -9,8 +9,8 @@ from .dependencies_pb2 import HelloReply, DESCRIPTOR
 from .dependency1_pb2 import Dependency1
 from .dependency2_pb2 import Dependency2
 
-class Greeter(GreeterServicer):
 
+class Greeter(GreeterServicer):
     def SayHello(self, request, context):
         """
         Unary-Unary
@@ -19,9 +19,13 @@ class Greeter(GreeterServicer):
         if context.invocation_metadata():
             for key, value in context.invocation_metadata():
                 if key == "password" and value == "12345":
-                    return HelloReply(message=f"Hello, {request.name}, password accepted!")
+                    return HelloReply(
+                        message=f"Hello, {request.name}, password accepted!"
+                    )
                 if key == "interceptor" and value == "true":
-                    return HelloReply(message=f"Hello, {request.name}, interceptor accepted!")
+                    return HelloReply(
+                        message=f"Hello, {request.name}, interceptor accepted!"
+                    )
         return HelloReply(message=f"Hello, {request.name}!")
 
     def SayHelloGroup(self, request, context):
@@ -39,9 +43,7 @@ class Greeter(GreeterServicer):
         Sends a HelloReply based on the name recieved from a stream of
         HelloRequests.
         """
-        names = []
-        for request in request_iterator:
-            names.append(request.name)
+        names = [request.name for request in request_iterator]
         names_string = " ".join(names)
         return HelloReply(message=f"Hello, {names_string}!")
 
@@ -60,24 +62,24 @@ class Greeter(GreeterServicer):
         """
         return Dependency1(field2=Dependency2)
 
-class HelloWorldServer():
 
+class HelloWorldServer:
     server = None
 
     def __init__(self, port: str):
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
         add_GreeterServicer_to_server(Greeter(), self.server)
         SERVICE_NAMES = (
-            DESCRIPTOR.services_by_name['Greeter'].full_name,
+            DESCRIPTOR.services_by_name["Greeter"].full_name,
             reflection.SERVICE_NAME,
         )
         reflection.enable_server_reflection(SERVICE_NAMES, self.server)
-        self.server.add_insecure_port(f'[::]:{port}')
+        self.server.add_insecure_port(f"[::]:{port}")
 
     def serve(self):
-        logging.debug('Server starting...')
+        logging.debug("Server starting...")
         self.server.start()
-        logging.debug('Server running...')
+        logging.debug("Server running...")
         self.server.wait_for_termination()
 
     def shutdown(self):


### PR DESCRIPTION
- Use `nox` to make it easier to test changes for both Protobuf 4 and 5
- Fix tests to allow Protobuf 5
- Update test code to be linted and formatted
- Update linting and formatting rules to be a bit more concise
- Update docs to indicate support commitments for Python and Protobuf versions
- Update Github test action to test along Python and Protobuf lines
- Update Github test action to only run linting and formatting checks once