### PR TITLE
bugfix: support AsyncIterable stream_requests_data in parse_stream_requests

### DIFF
--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -146,7 +146,7 @@ class BaseAsyncClient:
 class MessageParsersProtocol(Protocol):
     def parse_request_data(self, request_data, input_type): ...
 
-    async def parse_stream_requests(self, stream_requests_data: AsyncIterable, input_type): ...
+    async def parse_stream_requests(self, stream_requests_data: Iterable | AsyncIterable, input_type): ...
 
     async def parse_response(self, response): ...
 
@@ -159,9 +159,13 @@ class MessageParsers(MessageParsersProtocol):
         request = ParseDict(_data, input_type()) if isinstance(_data, dict) else _data
         return request
 
-    async def parse_stream_requests(self, stream_requests_data: AsyncIterable, input_type):
-        async for request_data in stream_requests_data:
-            yield self.parse_request_data(request_data or {}, input_type)
+    async def parse_stream_requests(self, stream_requests_data: Iterable | AsyncIterable, input_type):
+        if isinstance(stream_requests_data, Iterable):
+            for request_data in stream_requests_data:
+                yield self.parse_request_data(request_data or {}, input_type)
+        elif isinstance(stream_requests_data, AsyncIterable):
+            async for request_data in stream_requests_data:
+                yield self.parse_request_data(request_data or {}, input_type)
 
     async def parse_response(self, response):
         return MessageToDict(response, preserving_proto_field_name=True)
@@ -191,9 +195,13 @@ class CustomArgumentParsers(MessageParsersProtocol):
             request = _data
         return request
 
-    async def parse_stream_requests(self, stream_requests_data: AsyncIterable, input_type):
-        async for request_data in stream_requests_data:
-            yield self.parse_request_data(request_data or {}, input_type)
+    async def parse_stream_requests(self, stream_requests_data: Iterable | AsyncIterable, input_type):
+        if isinstance(stream_requests_data, Iterable):
+            for request_data in stream_requests_data:
+                yield self.parse_request_data(request_data or {}, input_type)
+        elif isinstance(stream_requests_data, AsyncIterable):
+            async for request_data in stream_requests_data:
+                yield self.parse_request_data(request_data or {}, input_type)
 
     async def parse_response(self, response):
         return MessageToDict(response, **self._message_to_dict_kwargs)

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -146,7 +146,9 @@ class BaseAsyncClient:
 class MessageParsersProtocol(Protocol):
     def parse_request_data(self, request_data, input_type): ...
 
-    async def parse_stream_requests(self, stream_requests_data: Iterable | AsyncIterable, input_type): ...
+    async def parse_stream_requests(
+        self, stream_requests_data: Union[Iterable, AsyncIterable], input_type
+    ): ...
 
     async def parse_response(self, response): ...
 
@@ -159,7 +161,9 @@ class MessageParsers(MessageParsersProtocol):
         request = ParseDict(_data, input_type()) if isinstance(_data, dict) else _data
         return request
 
-    async def parse_stream_requests(self, stream_requests_data: Iterable | AsyncIterable, input_type):
+    async def parse_stream_requests(
+        self, stream_requests_data: Union[Iterable, AsyncIterable], input_type
+    ):
         if isinstance(stream_requests_data, Iterable):
             for request_data in stream_requests_data:
                 yield self.parse_request_data(request_data or {}, input_type)
@@ -195,7 +199,9 @@ class CustomArgumentParsers(MessageParsersProtocol):
             request = _data
         return request
 
-    async def parse_stream_requests(self, stream_requests_data: Iterable | AsyncIterable, input_type):
+    async def parse_stream_requests(
+        self, stream_requests_data: Union[Iterable, AsyncIterable], input_type
+    ):
         if isinstance(stream_requests_data, Iterable):
             for request_data in stream_requests_data:
                 yield self.parse_request_data(request_data or {}, input_type)

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -146,7 +146,7 @@ class BaseAsyncClient:
 class MessageParsersProtocol(Protocol):
     def parse_request_data(self, request_data, input_type): ...
 
-    def parse_stream_requests(self, stream_requests_data: Iterable, input_type): ...
+    async def parse_stream_requests(self, stream_requests_data: AsyncIterable, input_type): ...
 
     async def parse_response(self, response): ...
 
@@ -159,8 +159,8 @@ class MessageParsers(MessageParsersProtocol):
         request = ParseDict(_data, input_type()) if isinstance(_data, dict) else _data
         return request
 
-    def parse_stream_requests(self, stream_requests_data: Iterable, input_type):
-        for request_data in stream_requests_data:
+    async def parse_stream_requests(self, stream_requests_data: AsyncIterable, input_type):
+        async for request_data in stream_requests_data:
             yield self.parse_request_data(request_data or {}, input_type)
 
     async def parse_response(self, response):
@@ -191,8 +191,8 @@ class CustomArgumentParsers(MessageParsersProtocol):
             request = _data
         return request
 
-    def parse_stream_requests(self, stream_requests_data: Iterable, input_type):
-        for request_data in stream_requests_data:
+    async def parse_stream_requests(self, stream_requests_data: AsyncIterable, input_type):
+        async for request_data in stream_requests_data:
             yield self.parse_request_data(request_data or {}, input_type)
 
     async def parse_response(self, response):


### PR DESCRIPTION
with the current implementation, it is not possible to pass an `AsyncIterable` to a rpc with stream requests.
the official gRPC API seems to accept both though: https://github.com/grpc/grpc/blob/8342a109aece77f04147b0a82a4e09ba25466e03/examples/python/route_guide/asyncio_route_guide_client.py#L97-L98